### PR TITLE
Check that node exists in graph before getting shortest paths

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0cb14f004ab9144eed24771ffaab3c5b61c0187bedd013d079885ec684bb1ccc"
+            "sha256": "f63a1c0ae485ecc3287a917b405f756019ede665d6174751d0cd7ef338214612"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f63a1c0ae485ecc3287a917b405f756019ede665d6174751d0cd7ef338214612"
+            "sha256": "0cb14f004ab9144eed24771ffaab3c5b61c0187bedd013d079885ec684bb1ccc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,32 +32,32 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0739146eaf4985962f07c62f7133aca89f3a600faac891ce6c7f3a1e2afe5272",
-                "sha256:07e21f14490324cc1160db101e9b6c1233c33985af4cb1d301dd02650fea1d7f",
-                "sha256:0f6a5ed0cd7ab1da11f5c07a8ecada73fc55a70ef7bb6311a4109891341d7277",
-                "sha256:0fd65cbbfdbf76bbf80c445d923b3accefea0fe2c2082049e0ce947c81fe1d3f",
-                "sha256:20cac3123d791e4bf8482a580d98d6b5969ba348b9d5364df791ba3a666b660d",
-                "sha256:528ce59ded2008f9e8543e0146acb3a98a9890da00adf8904b1e18c82099418b",
-                "sha256:56e392b7c738bd70e6f46cf48c8194d3d1dd4c5a59fae4b30c58bb6ef86e5233",
-                "sha256:675e0f23967ce71067d12b6944add505d5f0a251f819cfb44bdf8ee7072c090d",
-                "sha256:6be6b0ca705321c178c9858e5ad5611af664bbdfae1df1541f938a840a103888",
-                "sha256:719d914f564f35cce4dc103808f8297c807c9f0297ac183ed81ae8b5650e698e",
-                "sha256:768e777cc1ffdbf97c507f65975c8686ebafe0f3dc8925d02ac117acc4669ce9",
-                "sha256:7f76d406c6b998d6410198dcb82688dcdaec7d846aa87e263ccf52efdcfeba30",
-                "sha256:8c18ee4dddd5c6a811930c0a7c7947bf16387da3b394725f6063f1366311187d",
-                "sha256:99051e03b445117b26028623f1a487112ddf61a09a27e2d25e6bc07d37d94f25",
-                "sha256:a1413d06abfa942ca0553bf3bccaff5fdb36d55b84f2248e36228db871147dab",
-                "sha256:a7157c9ac6bddd2908c35ef099e4b643bc0e0ebb4d653deb54891d29258dd329",
-                "sha256:a958bf9d4834c72dee4f91a0476e7837b8a2966dc6fcfc42c421405f98d0da51",
-                "sha256:bb370120de6d26004358611441e07acda26840e41dfedc259d7f8cc613f96495",
-                "sha256:d0928076d9bd8a98de44e79b1abe50c1456e7abbb40af7ef58092086f1a6c729",
-                "sha256:d858423f5ed444d494b15c4cc90a206e1b8c31354c781ac7584da0d21c09c1c3",
-                "sha256:e6120d63b50e2248219f53302af7ec6fa2a42ed1f37e9cda2c76dbaca65036a7",
-                "sha256:f2b1378b63bdb581d5d7af2ec0373c8d40d651941d283a2afd7fc71184b3f570",
-                "sha256:facc6f925c3099ac01a1f03758100772560a0b020fb9d70f210404be08006bcb"
+                "sha256:0074d42e2cc333800bd09996223d40ec52e3b1ec0a5cab05dacc09b662c4c1ae",
+                "sha256:034717bfef517858abc79324820a702dc6cd063effb9baab86533e8a78670689",
+                "sha256:0db6301324d0568089663ef2701ad90ebac0e975742c97460e89366692bd0563",
+                "sha256:1864d005b2eb7598063e35c320787d87730d864f40d6410f768fe4ea20672016",
+                "sha256:46ce8323ca9384814c7645298b8b627b7d04ce97d6948ef02da357b2389d6972",
+                "sha256:510863d606c932b41d2209e4de6157ab3fdf52001d3e4ad351103176d33c4b8b",
+                "sha256:560e23a12e7599be8e8b67621396c5bc687fd54b48b890adbc71bc5a67333f86",
+                "sha256:57dc6c22d59054542600fce6fae2d1189b9c50bafc1aab32e55f7efcc84a6c46",
+                "sha256:760550fdf9d8ec7da9c4402a4afe6e25c0f184ae132011676298a6b636660b45",
+                "sha256:8670067685051b49d1f2f66e396488064299fefca199c7c80b6ba0c639fedc98",
+                "sha256:9016692c7d390f9d378fc88b7a799dc9caa7eb938163dda5276d3f3d6f75debf",
+                "sha256:98ff275f1b5907490d26b30b6ff111ecf2de0254f0ab08833d8fe61aa2068a00",
+                "sha256:9ccf4d5c9139b1e985db915039baa0610a7e4a45090580065f8d8cb801b7422f",
+                "sha256:a8dbab311d4259de5eeaa5b4e83f5f8545e4808f9144e84c0f424a6ee55a7b98",
+                "sha256:aaef1bea636b6e552bbc5dae0ada87d4f6046359daaa97a05a013b0169620f27",
+                "sha256:b8987e30d9a0eb6635df9705a75cf8c4a2835590244baecf210163343bc65176",
+                "sha256:c3fe23df6fe0898e788581753da453f877350058c5982e85a8972feeecb15309",
+                "sha256:c5eb7254cfc4bd7a4330ad7e1f65b98343836865338c57b0e25c661e41d5cfd9",
+                "sha256:c80fcf9b38c7f4df666150069b04abbd2fe42ae640703a6e1f128cda83b552b7",
+                "sha256:e33baf50f2f6b7153ddb973601a11df852697fba4c08b34a5e0f39f66f8120e1",
+                "sha256:e8578a62a8eaf552b95d62f630bb5dd071243ba1302bbff3e55ac48588508736",
+                "sha256:f22b3206f1c561dd9110b93d144c6aaa4a9a354e3b07ad36030df3ea92c5bb5b",
+                "sha256:f39afab5769b3aaa786634b94b4a23ef3c150bdda044e8a32a3fc16ddafe803b"
             ],
             "index": "pypi",
-            "version": "==1.14.2"
+            "version": "==1.14.3"
         },
         "pandas": {
             "hashes": [
@@ -138,10 +138,10 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
         },
         "gitdb2": {
             "hashes": [
@@ -183,11 +183,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
-                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
+                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
+            "version": "==3.5.1"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Create one **kspath.deviation_path.mps.SingleTargetDeviationPathAlgorithm** obje
 **Returns**
 * _kspath.deviation_path.mps.SingleTargetDeviationPathAlgorithm_ object
 
+**Raises**
+* _NodeNotFound_ – If target does not exist in _G_
+
 ### 2. **kspath.deviation_path.mps.SingleTargetDeviationPathAlgorithm**.shortest_simple_paths(_source_)
 
 **Parameters**
@@ -33,6 +36,9 @@ Create one **kspath.deviation_path.mps.SingleTargetDeviationPathAlgorithm** obje
 
 **Returns**
 * _generator_
+
+**Raises**
+* _NodeNotFound_ – If source does not exist in _G_
 
 ```python
 from kspath.deviation_path.mps import SingleTargetDeviationPathAlgorithm

--- a/kspath/deviation_path/mps.py
+++ b/kspath/deviation_path/mps.py
@@ -235,6 +235,9 @@ class SingleTargetDeviationPathAlgorithm(object):
                 List of nodes indicating the kth shortest simple path from
                 source to self.target
         """
+        if source not in self.graph.nodes:
+            raise nx.NodeNotFound
+        
         # check that there is actually a path from source to self.target
         if source in self._paths:
             candidate_paths = PathBuffer()

--- a/kspath/deviation_path/mps.py
+++ b/kspath/deviation_path/mps.py
@@ -103,6 +103,9 @@ class SingleTargetDeviationPathAlgorithm(object):
                 value if one wants to search for an unlimited number of
                 deviation paths.
         """
+        if target not in G:
+            raise nx.NodeNotFound('target node %s not in graph' % target)
+
         dist, paths = nx.single_source_dijkstra(G_reverse, target)
         for node in paths:
             paths[node] = paths[node][::-1]
@@ -221,7 +224,7 @@ class SingleTargetDeviationPathAlgorithm(object):
                         list_x.push(path_cost + cost, new_path, i, path_cost)
                     break
 
-    def shortest_simple_paths(self, source):
+    def _shortest_simple_paths(self, source):
         """Determines the K shortest simple paths from a source to self.target
 
         Parameters
@@ -235,9 +238,6 @@ class SingleTargetDeviationPathAlgorithm(object):
                 List of nodes indicating the kth shortest simple path from
                 source to self.target
         """
-        if source not in self.graph.nodes:
-            raise nx.NodeNotFound
-        
         # check that there is actually a path from source to self.target
         if source in self._paths:
             candidate_paths = PathBuffer()
@@ -289,3 +289,25 @@ class SingleTargetDeviationPathAlgorithm(object):
                                                      'weight'):
                     if tuple(path) not in simple_paths_found:
                         yield path
+
+    def shortest_simple_paths(self, source):
+        """Determines the K shortest simple paths from a source to self.target
+
+        Parameters
+        ----------
+            source : str
+                The source node of interest
+
+        Returns
+        ------
+            : mps._shortest_simple_paths
+                Generator object which yields the kth shortest simple path.
+
+        Raises
+        ------
+            networkx.NodeNotFound : If source is not in graph
+        """
+        if source not in self.graph:
+            raise nx.NodeNotFound('source node %s not in graph' % source)
+
+        return self._shortest_simple_paths(source)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pip install .
 from setuptools import setup, find_packages
 
 setup(name='kspath',
-      version='0.1.0',
+      version='0.1.1',
       description='Implements algorithms for the K shortest path problem.',
       author='Chong Hon Fah',
       author_email='hfchong@data.gov.sg',

--- a/tests/test_deviation_path_algorithm.py
+++ b/tests/test_deviation_path_algorithm.py
@@ -7,7 +7,8 @@ from kspath.deviation_path.mps import (
 from tests.utils import check_dpa_mps_implementation, compute_path_weight
 
 
-def test_node_not_found():
+@pytest.mark.fast
+def test_target_node_not_found():
     G = nx.DiGraph()
     G.add_edge('a', 'b', weight=0.6)
     G.add_edge('a', 'c', weight=0.2)
@@ -16,7 +17,25 @@ def test_node_not_found():
     G.add_edge('c', 'f', weight=0.9)
     G.add_edge('a', 'd', weight=0.3)
 
-    dpa_mps = SingleTargetDeviationPathAlgorithm.create_from_graph(G=G, target='d', weight='weight')
+    with pytest.raises(nx.NodeNotFound):
+        SingleTargetDeviationPathAlgorithm.create_from_graph(
+            G=G, target='z', weight='weight'
+        )
+
+
+@pytest.mark.fast
+def test_source_node_not_found():
+    G = nx.DiGraph()
+    G.add_edge('a', 'b', weight=0.6)
+    G.add_edge('a', 'c', weight=0.2)
+    G.add_edge('c', 'd', weight=0.1)
+    G.add_edge('c', 'e', weight=0.7)
+    G.add_edge('c', 'f', weight=0.9)
+    G.add_edge('a', 'd', weight=0.3)
+
+    dpa_mps = SingleTargetDeviationPathAlgorithm.create_from_graph(
+        G=G, target='d', weight='weight'
+    )
     
     with pytest.raises(nx.NodeNotFound):
         dpa_mps.shortest_simple_paths(source='z')

--- a/tests/test_deviation_path_algorithm.py
+++ b/tests/test_deviation_path_algorithm.py
@@ -7,6 +7,21 @@ from kspath.deviation_path.mps import (
 from tests.utils import check_dpa_mps_implementation, compute_path_weight
 
 
+def test_node_not_found():
+    G = nx.DiGraph()
+    G.add_edge('a', 'b', weight=0.6)
+    G.add_edge('a', 'c', weight=0.2)
+    G.add_edge('c', 'd', weight=0.1)
+    G.add_edge('c', 'e', weight=0.7)
+    G.add_edge('c', 'f', weight=0.9)
+    G.add_edge('a', 'd', weight=0.3)
+
+    dpa_mps = SingleTargetDeviationPathAlgorithm.create_from_graph(G=G, target='d', weight='weight')
+    
+    with pytest.raises(nx.NodeNotFound):
+        dpa_mps.shortest_simple_paths(source='z')
+
+
 @pytest.mark.fast
 def test_deviation_path_fast():
     G = nx.DiGraph()


### PR DESCRIPTION
I think querying for a non-existent node should raise an exception (e.g. nx.NodeNotFound) rather than fail silently and returning an empty list. This is consistent with how networkx behaves when you try to get shortest paths involving non-existent nodes.
```python
import networkx as nx
from kspath.deviation_path.mps import SingleTargetDeviationPathAlgorithm

G = nx.DiGraph()

G.add_edge('a', 'b', weight=0.6)
G.add_edge('a', 'c', weight=0.2)
G.add_edge('c', 'd', weight=0.1)
G.add_edge('c', 'e', weight=0.7)
G.add_edge('c', 'f', weight=0.9)
G.add_edge('a', 'd', weight=0.3)

dpa_mps = SingleTargetDeviationPathAlgorithm.create_from_graph(G=G, target='d', weight='weight')

dpa_mps.shortest_simple_paths(source='z')  # should raise an exception
```